### PR TITLE
Support for multiple *.tex files in one directory

### DIFF
--- a/ftplugin/tex_evinceSync.vim
+++ b/ftplugin/tex_evinceSync.vim
@@ -69,6 +69,14 @@ function! SVED_Sync()
 				break
 			endif
 		endif
+		let l:matches = glob(expand('%:r').".synctex.gz", 0, 1)
+		if !empty(l:matches)
+			let l:pdffile = fnamemodify(l:matches[0],":p:r:r" ) . ".pdf"
+			if filereadable(l:pdffile)
+				let l:foundpdf = 1
+				break
+			endif
+		endif
 		let l:matches = glob("*.synctex.gz", 0, 1)
 		if !empty(l:matches)
 			let l:pdffile = fnamemodify(l:matches[0],":p:r:r" ) . ".pdf"


### PR DESCRIPTION
For example in a latex subfile project: https://en.wikibooks.org/wiki/LaTeX/Modular_Documents#Subfiles

Check first for a *.synctex.gz file with same base name as the current file