### PR TITLE
Various tweaks

### DIFF
--- a/doc/sved.txt
+++ b/doc/sved.txt
@@ -1,0 +1,48 @@
+*sved.txt*  Synctex-based synchronisation between VIM or Neovim and evince.
+
+INTRODUCTION                                    *sved*
+
+SVED is a Vim plugin enabling synctex synchronization support for Vim and
+Evince through DBus. It provides
+ - |sved-forward-search|: a function to highlight the current buffer
+   line in evince
+ - |sved-backward-search|: When you hit <C-LeftMouse> in evince, the cursor
+   will automatically move in VIM to the matching location in the buffer.
+
+DEPENDENCIES                                    *sved-dependencies*
+
+SVED requires:
+ - VIM 8+ or Neovim
+ - python3 on the path with the modules pygobject3, dbus-python and neovim
+ - Evince 3.0+
+
+Your latex file must be compiled with synctex support. This can be done by
+compiling your project with `pdflatex -synctex=1 main.tex` . This should leave
+a `main.synctex.gz` file in the main directory. If automatic detection of this
+file fails, you can also create an empty file named `main.tex.latexmain`
+alongside your `main.tex`.
+
+FORWARD SEARCH                                  *sved-forward-search*
+
+Forward search is provided by the following function:
+                                                *SVED_Sync*
+SVED_Sync()
+  Highlights the current buffer position in evince.  If the file is not yet
+  opened by evince, a new window will be opened for it.
+
+  You can map this function to a keybinding of your choice, for example: >
+    nmap <F4> :call SVED_Sync()<CR>
+<
+BACKWARD SEARCH                                 *sved-backward-search*
+
+<C-LeftMouse> in Evince will make Vim jump to the corresponding location in
+the buffer. If the file is not yet open, a new buffer will be created for it.
+
+TROUBLESHOOTING                                 *sved-debug*
+
+To debug the dbus bridge process, export the `SVED_DEBUG` environment variable
+before starting VIM. A log file will be created in the current working
+directory.
+
+
+ vim:tw=78:ts=2:ft=help:norl:et

--- a/ftplugin/evinceSync.py
+++ b/ftplugin/evinceSync.py
@@ -194,7 +194,7 @@ def start_source_sync_daemon(is_neovim):
 def main(enable_logging=False):
     """Main function: setup dbus mainloop and call sync_view
     or start source_sync_daemon depending on sys.argv arguments"""
-    if enable_logging: # Switch to enable debugging to file
+    if enable_logging:
         logging.basicConfig(
             format='%(asctime)s %(levelname)s:%(message)s',
             filename='sved_%d.log' % os.getpid(),
@@ -233,4 +233,4 @@ def main(enable_logging=False):
     sys.exit(0)
 
 if __name__ == "__main__":
-    main()
+    main(enable_logging=os.environ.get("SVED_DEBUG"))

--- a/ftplugin/tex_evinceSync.vim
+++ b/ftplugin/tex_evinceSync.vim
@@ -37,10 +37,10 @@ function! SVED_NeovimOnExit(job, code, event) dict
 endfunction
 
 if has("nvim")
-	let g:evinceSyncDaemonJob = jobstart(["python3", s:pycmd, "1"],
+	let g:evinceSyncDaemonJob = jobstart([s:pycmd, "1"],
 				\ {"on_exit": "SVED_NeovimOnExit", "rpc": v:true})
 else
-	let g:evinceSyncDaemonJob = job_start(["python3", s:pycmd, "0"],
+	let g:evinceSyncDaemonJob = job_start([s:pycmd, "0"],
 				\ {"exit_cb": "SVED_VimOnExit", "in_mode": "json", "out_mode": "json"})
 endif
 
@@ -102,7 +102,7 @@ function! SVED_Sync()
 
 	let l:cursorpos = getcurpos()
 
-	let l:command = "python3 " . shellescape(s:pycmd) . " " . shellescape(l:pdffile) . " " . 
+	let l:command = shellescape(s:pycmd) . " " . shellescape(l:pdffile) . " " .
 				\ l:cursorpos[1] . " " . l:cursorpos[2] . " " . shellescape(expand("%:p"))
 	let l:output = system(l:command)
 	echo l:output

--- a/ftplugin/tex_evinceSync.vim
+++ b/ftplugin/tex_evinceSync.vim
@@ -29,7 +29,10 @@ function! SVED_VimOnExit(job, code)
 endfunction
 
 function! SVED_NeovimOnExit(job, code, event) dict
-	echom "evinceSynctex job quit with status " . a:code
+	if a:code != 0 || string(v:exiting) == "v:null"
+		" don't print a message on exit for code 0, we don't care
+		echom "evinceSynctex job quit with status " . a:code
+	endif
 	let g:loaded_evinceSync = 0
 endfunction
 


### PR DESCRIPTION
Hello,
I want to package this plugin for nixpkgs, and since this required some patching and I had to make a PR to send the patches upstream, I figured I would add some more "cosmetic" changes. This results in this somewhat heterogeneous PR, I'll split it in several ones or drop commits if you want.

* enable logging without modifying the script by setting the SVED_DEBUG environment variable
* add a vim documentation file, heavily inspired by the existing README. I am open to rephrasing.
* don't print a message when quitting neovim if the exit code is 0. This is neovim specific because I use `v:exiting`.
* Don't call evinceSync as `python3 evinceSync.py` but `/absolute/path/to/evinceSync.py` and trust the shebang. This one is required by the specificities of nixpkgs, which relies one weird shebangs, but it should not harm other distros, so I sent it upstream anyway. Feel free to tell me if you would rather keep this patch downstream.