### PR TITLE
don't drop unsaved changes in the buffer when syncing from evince to vim

### DIFF
--- a/doc/sved.txt
+++ b/doc/sved.txt
@@ -37,6 +37,7 @@ BACKWARD SEARCH                                 *sved-backward-search*
 
 <C-LeftMouse> in Evince will make Vim jump to the corresponding location in
 the buffer. If the file is not yet open, a new buffer will be created for it.
+Having |'switchbuf'| set to `useopen` is advised.
 
 TROUBLESHOOTING                                 *sved-debug*
 


### PR DESCRIPTION
This fixes the following undesired behavior:

1/ edit, save, compile a tex file
2/ modify the file further without saving
3/ ctrl+click in evince somewhere
local changes of 2/ are lost.

Inspired from https://superuser.com/questions/729075/vim-command-that-will-do-buff-or-e-if-the-file-is-not-already-in-the-buffer